### PR TITLE
Added max width to svg images

### DIFF
--- a/build.js
+++ b/build.js
@@ -112,7 +112,7 @@ function episodeContent(){
             '<p>' + linkContent +
             '</p>' +
             '</div>'
-          );          
+          );
         }
 
         // if picks add picks

--- a/episode.html
+++ b/episode.html
@@ -27,7 +27,7 @@
                 <a href="/" class="logo">
                     <?xml version="1.0" encoding="utf-8"?>
                     <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-                         viewBox="0 0 400 240" style="enable-background:new 0 0 400 240;" xml:space="preserve">
+                         viewBox="0 0 400 240" style="enable-background:new 0 0 400 240; max-width: 100%;" xml:space="preserve">
                     <style type="text/css">
                         .st0{fill:#E2E3E1;}
                     </style>

--- a/public/img/front-end-happy-hour-logo.svg
+++ b/public/img/front-end-happy-hour-logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 400 240" style="enable-background:new 0 0 400 240;" xml:space="preserve">
+	 viewBox="0 0 400 240" style="enable-background:new 0 0 400 240; max-width: 100%;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#E2E3E1;}
 </style>

--- a/public/img/front-end-happy-hour.svg
+++ b/public/img/front-end-happy-hour.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 240 40" style="enable-background:new 0 0 240 40;" xml:space="preserve">
+	 viewBox="0 0 240 40" style="enable-background:new 0 0 240 40; max-width: 100%;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#E2E3E1;}
 </style>

--- a/public/img/podcast.svg
+++ b/public/img/podcast.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 400 240" style="enable-background:new 0 0 400 240;" xml:space="preserve">
+	 viewBox="0 0 400 240" style="enable-background:new 0 0 400 240; max-width: 100%;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 </style>

--- a/public/img/rss.svg
+++ b/public/img/rss.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 400 240" style="enable-background:new 0 0 400 240;" xml:space="preserve">
+	 viewBox="0 0 400 240" style="enable-background:new 0 0 400 240; max-width: 100%;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 </style>

--- a/public/img/twitter.svg
+++ b/public/img/twitter.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 16.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 -150 812 812" style="enable-background:new 0 0 300 300;" xml:space="preserve">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 -150 812 812" style="enable-background:new 0 0 300 300; max-width: 100%;" xml:space="preserve">
 <style type="text/css">
   .st0{fill:#FFFFFF;}
 </style>


### PR DESCRIPTION
Adding max width to svg images to avoid issues like this one below:

![screen shot 2016-04-08 at 9 42 35 pm](https://cloud.githubusercontent.com/assets/1207250/14401791/d4f1d696-fdd2-11e5-8b9b-f2a8050356e7.png)
